### PR TITLE
Configuration API

### DIFF
--- a/src/main/java/net/TheDgtl/Stargate/Stargate.java
+++ b/src/main/java/net/TheDgtl/Stargate/Stargate.java
@@ -20,6 +20,7 @@ package net.TheDgtl.Stargate;
 import net.TheDgtl.Stargate.api.StargateAPI;
 import net.TheDgtl.Stargate.command.CommandStargate;
 import net.TheDgtl.Stargate.command.StargateTabCompleter;
+import net.TheDgtl.Stargate.config.ConfigurationAPI;
 import net.TheDgtl.Stargate.config.ConfigurationHelper;
 import net.TheDgtl.Stargate.config.ConfigurationOption;
 import net.TheDgtl.Stargate.config.StargateYamlConfiguration;
@@ -82,7 +83,7 @@ import java.util.logging.Level;
  * @author Drakia (2011-2013)
  * @author Dinnerbone (2010-2011)
  */
-public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI {
+public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI, ConfigurationAPI {
     private static Stargate instance;
 
     private Level lowestMessageLevel = Level.INFO;//setting before config loads
@@ -266,6 +267,21 @@ public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI 
         }
     }
 
+    @Override
+    public void setConfigurationOptionValue(ConfigurationOption configurationOption, Object newValue) {
+        config.set(configurationOption.getConfigNode(), newValue);
+    }
+
+    @Override
+    public Object getConfigurationOptionValue(ConfigurationOption configurationOption) {
+        return config.get(configurationOption.getConfigNode());
+    }
+
+    @Override
+    public void saveConfiguration() {
+        saveConfig();
+    }
+
     public void reload() {
         loadGateFormats();
         load();
@@ -372,7 +388,12 @@ public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI 
     public static StorageAPI getStorageAPIStatic() {
         return instance.storageAPI;
     }
-    
+
+    @SuppressWarnings("unused")
+    public static ConfigurationAPI getConfigAPIStatic() {
+        return instance;
+    }
+
     public static LanguageManager getLanguageManagerStatic() {
         return instance.languageManager;
     }
@@ -396,7 +417,10 @@ public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI 
     public PermissionManager getPermissionManager(Entity entity) {
         return new StargatePermissionManager(entity);
     }
-    
-    
+
+    @Override
+    public ConfigurationAPI getConfigurationAPI() {
+        return this;
+    }
 
 }

--- a/src/main/java/net/TheDgtl/Stargate/api/StargateAPI.java
+++ b/src/main/java/net/TheDgtl/Stargate/api/StargateAPI.java
@@ -1,10 +1,10 @@
 package net.TheDgtl.Stargate.api;
 
+import net.TheDgtl.Stargate.config.ConfigurationAPI;
 import net.TheDgtl.Stargate.database.StorageAPI;
 import net.TheDgtl.Stargate.formatting.LanguageManager;
 import net.TheDgtl.Stargate.manager.PermissionManager;
 import net.TheDgtl.Stargate.network.RegistryAPI;
-import org.bukkit.configuration.Configuration;
 import org.bukkit.entity.Entity;
 
 /**
@@ -12,6 +12,7 @@ import org.bukkit.entity.Entity;
  *
  * @author Thorin
  */
+@SuppressWarnings("unused")
 public interface StargateAPI {
 
     /**
@@ -19,41 +20,35 @@ public interface StargateAPI {
      *
      * @return <p>The registry used to register and unregister Stargates</p>
      */
-    public RegistryAPI getRegistry();
+    RegistryAPI getRegistry();
 
     /**
      * Gets the storage API used to store and load Stargates
      *
      * @return <p>The storage API used to store and load stargates</p>
      */
-    public StorageAPI getStorageAPI();
-    
+    StorageAPI getStorageAPI();
+
     /**
      * Gets permission manager for specified entity
+     *
      * @param entity <p> The entity to check permissions on </p>
      * @return <p> A permission manager </p>
      */
-    public PermissionManager getPermissionManager(Entity entity);
+    PermissionManager getPermissionManager(Entity entity);
 
     /**
-     * Reloads the Stargate configuration from disk
-     */
-    public void reload();
-
-    /**
-     * Gets Stargate's configuration
+     * Gets the configuration API used to interact with the configuration file
      *
-     * @return <p>Stargate's configuration</p>
+     * @return <p>The configuration API</p>
      */
-    public Configuration getConfig();
+    ConfigurationAPI getConfigurationAPI();
 
     /**
      * Gets the language manager used for translating strings
      *
      * @return <p>The language manager used for translating strings</p>
      */
-    public LanguageManager getLanguageManager();
-    
-    
+    LanguageManager getLanguageManager();
 
 }

--- a/src/main/java/net/TheDgtl/Stargate/config/ConfigurationAPI.java
+++ b/src/main/java/net/TheDgtl/Stargate/config/ConfigurationAPI.java
@@ -1,0 +1,41 @@
+package net.TheDgtl.Stargate.config;
+
+/**
+ * An API for interacting with Stargate's configuration file
+ *
+ * @author Kristian Knarvik (EpicKnarvik97)
+ */
+@SuppressWarnings("unused")
+public interface ConfigurationAPI {
+
+    /**
+     * Sets the value of a configuration option
+     *
+     * @param configurationOption <p>The configuration option to update</p>
+     * @param newValue            <p>The new value of the configuration option</p>
+     */
+    void setConfigurationOptionValue(ConfigurationOption configurationOption, Object newValue);
+
+    /**
+     * Gets the current value of a configuration option
+     *
+     * @param configurationOption <p>The configuration option to get the value of</p>
+     * @return <p>The current value of the specified configuration option</p>
+     */
+    Object getConfigurationOptionValue(ConfigurationOption configurationOption);
+
+    /**
+     * Saves the current state of the configuration to disk
+     *
+     * <p>This needs to be run after any config changes to update the config file.</p>
+     */
+    void saveConfiguration();
+
+    /**
+     * Reloads the configuration from disk
+     *
+     * <p>This needs to be executed in order for saved config changes to take effect.</p>
+     */
+    void reload();
+
+}


### PR DESCRIPTION
This change adds a ConfigurationAPI interface to improve and fix the current API.

The API has two simple methods for reading and saving configuration values which means there is no longer a reliance on the Spigot API's Configuration object. This makes it easier to change the config reading/writing implementation later on. The methods use the ConfigurationOption enum which makes it much more intuitive which configuration values are available.

The ConfigurationAPI adds the missing ability to save the configuration
This change moves reloading to the configuration API as reloading is somewhat related to config changes.