### PR TITLE
Makes legacy Bungee always use the legacy network #166

### DIFF
--- a/src/main/java/net/TheDgtl/Stargate/Stargate.java
+++ b/src/main/java/net/TheDgtl/Stargate/Stargate.java
@@ -124,14 +124,15 @@ public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI,
 
     public static ChatColor defaultLightSignColor;
     public static ChatColor defaultDarkColor;
+
     static {
-        if(VersionImplemented.CHAT_COLOR.getIsImplemented()) {
+        if (VersionImplemented.CHAT_COLOR.getIsImplemented()) {
             defaultLightSignColor = ChatColor.BLACK;
             defaultDarkColor = ChatColor.WHITE;
         }
-            
+
     }
-    
+
     public static org.bukkit.ChatColor legacyDefaultLightSignColor = org.bukkit.ChatColor.BLACK;
     public static org.bukkit.ChatColor legacyDefaultDarkSignColor = org.bukkit.ChatColor.WHITE;
 
@@ -174,13 +175,14 @@ public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI,
     }
 
     private void loadColors() {
-        if(!VersionImplemented.CHAT_COLOR.getIsImplemented()) {
-            logMessage(Level.INFO,"Default stargate coloring is not supported on your current server implementation");
+        if (!VersionImplemented.CHAT_COLOR.getIsImplemented()) {
+            logMessage(Level.INFO, "Default stargate coloring is not supported on your current server implementation");
             try {
                 Stargate.legacyDefaultDarkSignColor = org.bukkit.ChatColor.valueOf(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_LIGHT_SIGN_COLOR).toUpperCase());
                 Stargate.legacyDefaultLightSignColor = org.bukkit.ChatColor.valueOf(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_DARK_SIGN_COLOR).toUpperCase());
-                }  catch(IllegalArgumentException ignored) {}
-            
+            } catch (IllegalArgumentException ignored) {
+            }
+
             return;
         }
         try {

--- a/src/main/java/net/TheDgtl/Stargate/config/ConfigurationHelper.java
+++ b/src/main/java/net/TheDgtl/Stargate/config/ConfigurationHelper.java
@@ -42,6 +42,20 @@ public final class ConfigurationHelper {
     }
 
     /**
+     * Gets the string value of a setting, or the default value if not set
+     *
+     * @param configurationOption <p>The setting to get</p>
+     * @return <p>The value of the setting, or the default if not set</p>
+     */
+    public static String getStringOrDefault(ConfigurationOption configurationOption) {
+        if (Stargate.getFileConfiguration().isSet(configurationOption.getConfigNode())) {
+            return Stargate.getFileConfiguration().getString(configurationOption.getConfigNode());
+        } else {
+            return (String) configurationOption.getDefaultValue();
+        }
+    }
+
+    /**
      * Gets the boolean value of a setting
      *
      * @param configurationOption <p>The setting to get</p>

--- a/src/main/java/net/TheDgtl/Stargate/config/ConfigurationOption.java
+++ b/src/main/java/net/TheDgtl/Stargate/config/ConfigurationOption.java
@@ -15,6 +15,11 @@ public enum ConfigurationOption {
     DEFAULT_NETWORK("defaultGateNetwork", "The default network if no network is specified", "central", OptionDataType.STRING),
 
     /**
+     * The network used for all legacy BungeeCord Stargates
+     */
+    LEGACY_BUNGEE_NETWORK("legacyBungeeNetwork", "The network used for all legacy BungeeCord stargates", "LegacyBungee", OptionDataType.STRING),
+
+    /**
      * The language used for all translatable messages
      */
     LANGUAGE("language", "The language used for all translatable messages", "en", OptionDataType.LANGUAGE),

--- a/src/main/java/net/TheDgtl/Stargate/database/PortalDatabaseAPI.java
+++ b/src/main/java/net/TheDgtl/Stargate/database/PortalDatabaseAPI.java
@@ -17,6 +17,7 @@ import net.TheDgtl.Stargate.network.Network;
 import net.TheDgtl.Stargate.network.PersonalNetwork;
 import net.TheDgtl.Stargate.network.PortalType;
 import net.TheDgtl.Stargate.network.RegistryAPI;
+import net.TheDgtl.Stargate.network.portal.BungeePortal;
 import net.TheDgtl.Stargate.network.portal.Portal;
 import net.TheDgtl.Stargate.network.portal.PortalFlag;
 import net.TheDgtl.Stargate.network.portal.PortalPosition;
@@ -416,7 +417,7 @@ public class PortalDatabaseAPI implements StorageAPI {
 
             String targetNetwork = networkName;
             if (flags.contains(PortalFlag.BUNGEE)) {
-                targetNetwork = "§§§§§§#BUNGEE#§§§§§§";
+                targetNetwork = BungeePortal.getLegacyNetworkName();
             }
 
             try {

--- a/src/main/java/net/TheDgtl/Stargate/gate/GateAPI.java
+++ b/src/main/java/net/TheDgtl/Stargate/gate/GateAPI.java
@@ -15,7 +15,7 @@ import java.util.List;
  * An API describing a Gate
  */
 public interface GateAPI {
-    
+
     /**
      * Set button and draw sign
      *

--- a/src/main/java/net/TheDgtl/Stargate/gate/GateFormatParser.java
+++ b/src/main/java/net/TheDgtl/Stargate/gate/GateFormatParser.java
@@ -73,7 +73,7 @@ public class GateFormatParser {
         Map<Character, Set<Material>> characterMaterialMap = new HashMap<>();
         List<List<Character>> design = new ArrayList<>();
         Map<String, String> config = new HashMap<>();
-        int columns = GateFormatReader.readGateFile(scanner, characterMaterialMap, filename, design, config, logger);
+        int columns = GateFormatReader.readGateFile(scanner, characterMaterialMap, design, config);
 
         loadGateConfigValues(config);
         iris = new GateIris(irisOpen, irisClosed);

--- a/src/main/java/net/TheDgtl/Stargate/listener/BlockEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/BlockEventListener.java
@@ -11,6 +11,7 @@ import net.TheDgtl.Stargate.formatting.TranslatableMessage;
 import net.TheDgtl.Stargate.gate.structure.GateStructureType;
 import net.TheDgtl.Stargate.manager.StargatePermissionManager;
 import net.TheDgtl.Stargate.network.Network;
+import net.TheDgtl.Stargate.network.portal.BungeePortal;
 import net.TheDgtl.Stargate.network.portal.Portal;
 import net.TheDgtl.Stargate.network.portal.PortalFlag;
 import net.TheDgtl.Stargate.network.portal.RealPortal;
@@ -134,19 +135,23 @@ public class BlockEventListener implements Listener {
 
         String finalNetworkName;
         Network selectedNetwork = null;
-        try {
-            Stargate.log(Level.FINER, "....Choosing network name....");
-            Stargate.log(Level.FINER, "initial name is " + network);
-            finalNetworkName = NetworkCreationHelper.interpretNetworkName(network, flags, player, Stargate.getRegistryStatic());
-            Stargate.log(Level.FINER, "Took format " + finalNetworkName);
-            finalNetworkName = NetworkCreationHelper.getAllowedNetworkName(finalNetworkName, permissionManager, player);
-            Stargate.log(Level.FINER, "From allowed permissions took " + finalNetworkName);
-            flags.addAll(NetworkCreationHelper.getNameRelatedFlags(finalNetworkName));
-            finalNetworkName = NetworkCreationHelper.parseNetworkNameName(finalNetworkName);
-            Stargate.log(Level.FINER, "Ended upp with name " + finalNetworkName);
-            selectedNetwork = NetworkCreationHelper.selectNetwork(finalNetworkName, flags);
-        } catch (NameErrorException nameErrorException) {
-            errorMessage = nameErrorException.getErrorMessage();
+        if (flags.contains(PortalFlag.BUNGEE)) {
+            selectedNetwork = BungeePortal.getLegacyNetwork();
+        } else {
+            try {
+                Stargate.log(Level.FINER, "....Choosing network name....");
+                Stargate.log(Level.FINER, "initial name is " + network);
+                finalNetworkName = NetworkCreationHelper.interpretNetworkName(network, flags, player, Stargate.getRegistryStatic());
+                Stargate.log(Level.FINER, "Took format " + finalNetworkName);
+                finalNetworkName = NetworkCreationHelper.getAllowedNetworkName(finalNetworkName, permissionManager, player);
+                Stargate.log(Level.FINER, "From allowed permissions took " + finalNetworkName);
+                flags.addAll(NetworkCreationHelper.getNameRelatedFlags(finalNetworkName));
+                finalNetworkName = NetworkCreationHelper.parseNetworkNameName(finalNetworkName);
+                Stargate.log(Level.FINER, "Ended upp with name " + finalNetworkName);
+                selectedNetwork = NetworkCreationHelper.selectNetwork(finalNetworkName, flags);
+            } catch (NameErrorException nameErrorException) {
+                errorMessage = nameErrorException.getErrorMessage();
+            }
         }
 
 

--- a/src/main/java/net/TheDgtl/Stargate/listener/BlockEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/BlockEventListener.java
@@ -135,10 +135,10 @@ public class BlockEventListener implements Listener {
 
         String finalNetworkName;
         Network selectedNetwork = null;
-        if (flags.contains(PortalFlag.BUNGEE)) {
-            selectedNetwork = BungeePortal.getLegacyNetwork();
-        } else {
-            try {
+        try {
+            if (flags.contains(PortalFlag.BUNGEE)) {
+                selectedNetwork = NetworkCreationHelper.selectNetwork(BungeePortal.getLegacyNetworkName(), flags);
+            } else {
                 Stargate.log(Level.FINER, "....Choosing network name....");
                 Stargate.log(Level.FINER, "initial name is " + network);
                 finalNetworkName = NetworkCreationHelper.interpretNetworkName(network, flags, player, Stargate.getRegistryStatic());
@@ -149,11 +149,10 @@ public class BlockEventListener implements Listener {
                 finalNetworkName = NetworkCreationHelper.parseNetworkNameName(finalNetworkName);
                 Stargate.log(Level.FINER, "Ended upp with name " + finalNetworkName);
                 selectedNetwork = NetworkCreationHelper.selectNetwork(finalNetworkName, flags);
-            } catch (NameErrorException nameErrorException) {
-                errorMessage = nameErrorException.getErrorMessage();
             }
+        } catch (NameErrorException nameErrorException) {
+            errorMessage = nameErrorException.getErrorMessage();
         }
-
 
         try {
             PortalCreationHelper.tryPortalCreation(selectedNetwork, lines, block, flags, event.getPlayer(), cost, permissionManager, errorMessage);

--- a/src/main/java/net/TheDgtl/Stargate/listener/StargateBungeePluginMessageListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/StargateBungeePluginMessageListener.java
@@ -27,6 +27,7 @@ import net.TheDgtl.Stargate.exception.NameErrorException;
 import net.TheDgtl.Stargate.formatting.TranslatableMessage;
 import net.TheDgtl.Stargate.network.InterServerNetwork;
 import net.TheDgtl.Stargate.network.Network;
+import net.TheDgtl.Stargate.network.portal.BungeePortal;
 import net.TheDgtl.Stargate.network.portal.Portal;
 import net.TheDgtl.Stargate.network.portal.PortalFlag;
 import net.TheDgtl.Stargate.network.portal.VirtualPortal;
@@ -133,7 +134,7 @@ public class StargateBungeePluginMessageListener implements PluginMessageListene
      * @param message <p>The legacy connect message to parse and handle</p>
      */
     private void legacyPlayerConnect(String message) {
-        String bungeeNetwork = "§§§§§§#BUNGEE#§§§§§§";
+        String bungeeNetwork = BungeePortal.getLegacyNetworkName();
         String[] parts = message.split("#@#");
 
         String playerName = parts[0];

--- a/src/main/java/net/TheDgtl/Stargate/manager/StargatePermissionManager.java
+++ b/src/main/java/net/TheDgtl/Stargate/manager/StargatePermissionManager.java
@@ -294,12 +294,12 @@ public class StargatePermissionManager implements PermissionManager {
         }
 
         HighlightingStyle highlight = HighlightingStyle.getHighlightType(network);
-        String netName = HighlightingStyle.getNameFromHighlightedText(network);
+        String networkName = HighlightingStyle.getNameFromHighlightedText(network);
         boolean hasPermission;
 
         switch (highlight) {
             case PERSONAL:
-                if (target.getName().equals(netName)) {
+                if (target.getName().equals(networkName)) {
                     hasPermission = target.hasPermission(NETWORK_CREATE_PERMISSION + ".personal");
                 } else {
                     hasPermission = target.hasPermission(BypassPermission.PRIVATE.getPermissionString());
@@ -309,10 +309,13 @@ public class StargatePermissionManager implements PermissionManager {
                 hasPermission = target.hasPermission(NETWORK_CREATE_PERMISSION + ".type." + PortalFlag.FANCY_INTER_SERVER);
                 break;
             default:
-                if (netName.equals(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_NETWORK))) {
+                if (networkName.equals(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_NETWORK))) {
                     hasPermission = target.hasPermission(NETWORK_CREATE_PERMISSION + ".default");
+                } else if (networkName.equals(ConfigurationHelper.getStringOrDefault(ConfigurationOption.LEGACY_BUNGEE_NETWORK))) {
+                    //It's not possible to create a non-bungee portal on this network
+                    hasPermission = false;
                 } else {
-                    hasPermission = target.hasPermission(PortalPermissionHelper.generateCustomNetworkPermission(CREATE_PERMISSION, netName));
+                    hasPermission = target.hasPermission(PortalPermissionHelper.generateCustomNetworkPermission(CREATE_PERMISSION, networkName));
                 }
                 break;
         }

--- a/src/main/java/net/TheDgtl/Stargate/network/PersonalNetwork.java
+++ b/src/main/java/net/TheDgtl/Stargate/network/PersonalNetwork.java
@@ -33,9 +33,9 @@ public class PersonalNetwork extends LocalNetwork {
         Stargate.log(Level.FINER, "Matching player name: " + Bukkit.getOfflinePlayer(uuid).getName());
         String possiblePlayerName = Bukkit.getOfflinePlayer(uuid).getName();
         if (possiblePlayerName != null
-                && (possiblePlayerName.toLowerCase().equals(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_NETWORK).toLowerCase())
-                || possiblePlayerName.toLowerCase()
-                .equals(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_TERMINAL_NAME).toLowerCase()))) {
+                && (possiblePlayerName.equalsIgnoreCase(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_NETWORK))
+                || possiblePlayerName.equalsIgnoreCase(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_TERMINAL_NAME))
+                || possiblePlayerName.equalsIgnoreCase(ConfigurationHelper.getStringOrDefault(ConfigurationOption.LEGACY_BUNGEE_NETWORK)))) {
             possiblePlayerName = uuid.toString().split("-")[0];
         }
         playerName = possiblePlayerName;

--- a/src/main/java/net/TheDgtl/Stargate/network/portal/BungeePortal.java
+++ b/src/main/java/net/TheDgtl/Stargate/network/portal/BungeePortal.java
@@ -38,7 +38,6 @@ public class BungeePortal extends AbstractPortal {
     /**
      * Instantiates a new Bungee Portal
      *
-     * @param network           <p>The network the portal belongs to</p>
      * @param name              <p>The name of the portal</p>
      * @param destination       <p>The destination of the portal</p>
      * @param destinationServer <p>The destination server to connect to</p>
@@ -46,9 +45,9 @@ public class BungeePortal extends AbstractPortal {
      * @param ownerUUID         <p>The UUID of this portal's owner</p>
      * @throws NameErrorException <p>If the portal name is invalid</p>
      */
-    public BungeePortal(Network network, String name, String destination, String destinationServer,
+    public BungeePortal(String name, String destination, String destinationServer,
                         Set<PortalFlag> flags, Gate gate, UUID ownerUUID, StargateLogger logger) throws NameErrorException {
-        super(network, name, flags, gate, ownerUUID, logger);
+        super(getLegacyNetwork(), name, flags, gate, ownerUUID, logger);
 
 
         if (destination == null || destination.trim().isEmpty() || destinationServer == null || destinationServer.trim().isEmpty()) {
@@ -74,6 +73,15 @@ public class BungeePortal extends AbstractPortal {
         fakeNetwork = new LocalNetwork(destinationServer, null, null);
         String possibleBungeeString = Stargate.getLanguageManagerStatic().getString(TranslatableMessage.BUNGEE_SIGN_LINE_4);
         bungeeString = (possibleBungeeString == null) ? "[PlaceHolder]" : possibleBungeeString;
+    }
+
+    /**
+     * Gets the legacy network used for all legacy BungeeCord portals
+     *
+     * @return <p>The legacy network</p>
+     */
+    public static Network getLegacyNetwork() {
+        return LEGACY_NETWORK;
     }
 
     @Override

--- a/src/main/java/net/TheDgtl/Stargate/network/portal/BungeePortal.java
+++ b/src/main/java/net/TheDgtl/Stargate/network/portal/BungeePortal.java
@@ -2,6 +2,8 @@ package net.TheDgtl.Stargate.network.portal;
 
 import net.TheDgtl.Stargate.Stargate;
 import net.TheDgtl.Stargate.StargateLogger;
+import net.TheDgtl.Stargate.config.ConfigurationHelper;
+import net.TheDgtl.Stargate.config.ConfigurationOption;
 import net.TheDgtl.Stargate.exception.NameErrorException;
 import net.TheDgtl.Stargate.formatting.TranslatableMessage;
 import net.TheDgtl.Stargate.gate.Gate;
@@ -21,24 +23,15 @@ import java.util.logging.Level;
  */
 public class BungeePortal extends AbstractPortal {
 
-    private static final String legacyNetworkName = "§§§§§§#BUNGEE#§§§§§§";
-    private static Network LEGACY_NETWORK;
     private final Network fakeNetwork;
     private final LegacyVirtualPortal targetPortal;
     private final String serverDestination;
     private final String bungeeString;
 
-    static {
-        try {
-            LEGACY_NETWORK = new LocalNetwork(getLegacyNetworkName(), null, null);
-        } catch (NameErrorException e) {
-            e.printStackTrace();
-        }
-    }
-
     /**
      * Instantiates a new Bungee Portal
      *
+     * @param network           <p>A reference to the Legacy Bungee network</p>
      * @param name              <p>The name of the portal</p>
      * @param destination       <p>The destination of the portal</p>
      * @param destinationServer <p>The destination server to connect to</p>
@@ -46,10 +39,9 @@ public class BungeePortal extends AbstractPortal {
      * @param ownerUUID         <p>The UUID of this portal's owner</p>
      * @throws NameErrorException <p>If the portal name is invalid</p>
      */
-    public BungeePortal(String name, String destination, String destinationServer,
+    public BungeePortal(Network network, String name, String destination, String destinationServer,
                         Set<PortalFlag> flags, Gate gate, UUID ownerUUID, StargateLogger logger) throws NameErrorException {
-        super(getLegacyNetwork(), name, flags, gate, ownerUUID, logger);
-
+        super(network, name, flags, gate, ownerUUID, logger);
 
         if (destination == null || destination.trim().isEmpty() || destinationServer == null || destinationServer.trim().isEmpty()) {
             throw new NameErrorException(TranslatableMessage.BUNGEE_LACKING_SIGN_INFORMATION);
@@ -63,7 +55,7 @@ public class BungeePortal extends AbstractPortal {
          * Note that this is only used locally inside this portal
          * and can not be found (should not) in any network anywhere.
          */
-        targetPortal = new LegacyVirtualPortal(this, destinationServer, destination, LEGACY_NETWORK,
+        targetPortal = new LegacyVirtualPortal(this, destinationServer, destination, network,
                 EnumSet.noneOf(PortalFlag.class), ownerUUID);
         this.serverDestination = destinationServer;
         /*
@@ -81,16 +73,7 @@ public class BungeePortal extends AbstractPortal {
      * @return <p>The name of the legacy network</p>
      */
     public static String getLegacyNetworkName() {
-        return legacyNetworkName;
-    }
-
-    /**
-     * Gets the legacy network used for all legacy BungeeCord portals
-     *
-     * @return <p>The legacy network</p>
-     */
-    public static Network getLegacyNetwork() {
-        return LEGACY_NETWORK;
+        return ConfigurationHelper.getStringOrDefault(ConfigurationOption.LEGACY_BUNGEE_NETWORK);
     }
 
     @Override

--- a/src/main/java/net/TheDgtl/Stargate/network/portal/BungeePortal.java
+++ b/src/main/java/net/TheDgtl/Stargate/network/portal/BungeePortal.java
@@ -21,6 +21,7 @@ import java.util.logging.Level;
  */
 public class BungeePortal extends AbstractPortal {
 
+    private static final String legacyNetworkName = "§§§§§§#BUNGEE#§§§§§§";
     private static Network LEGACY_NETWORK;
     private final Network fakeNetwork;
     private final LegacyVirtualPortal targetPortal;
@@ -29,7 +30,7 @@ public class BungeePortal extends AbstractPortal {
 
     static {
         try {
-            LEGACY_NETWORK = new LocalNetwork("§§§§§§#BUNGEE#§§§§§§", null, null);
+            LEGACY_NETWORK = new LocalNetwork(getLegacyNetworkName(), null, null);
         } catch (NameErrorException e) {
             e.printStackTrace();
         }
@@ -54,7 +55,6 @@ public class BungeePortal extends AbstractPortal {
             throw new NameErrorException(TranslatableMessage.BUNGEE_LACKING_SIGN_INFORMATION);
         }
 
-
         /*
          * Create a virtual portal that handles everything related
          * to moving the player to a different server. This is set
@@ -73,6 +73,15 @@ public class BungeePortal extends AbstractPortal {
         fakeNetwork = new LocalNetwork(destinationServer, null, null);
         String possibleBungeeString = Stargate.getLanguageManagerStatic().getString(TranslatableMessage.BUNGEE_SIGN_LINE_4);
         bungeeString = (possibleBungeeString == null) ? "[PlaceHolder]" : possibleBungeeString;
+    }
+
+    /**
+     * Gets the name of the legacy network used for all legacy BungeeCord portals
+     *
+     * @return <p>The name of the legacy network</p>
+     */
+    public static String getLegacyNetworkName() {
+        return legacyNetworkName;
     }
 
     /**

--- a/src/main/java/net/TheDgtl/Stargate/network/portal/formatting/AbstractLineColorFormatter.java
+++ b/src/main/java/net/TheDgtl/Stargate/network/portal/formatting/AbstractLineColorFormatter.java
@@ -2,12 +2,14 @@ package net.TheDgtl.Stargate.network.portal.formatting;
 
 import org.bukkit.Material;
 
-public abstract class AbstractLineColorFormatter implements LineFormatter{
-    
+public abstract class AbstractLineColorFormatter implements LineFormatter {
+
     protected final boolean isLightSign;
+
     public AbstractLineColorFormatter(Material signMaterial) {
         this.isLightSign = isLightSign(signMaterial);
     }
+
     /**
      * Checks whether the given sign material represents a light sign or a dark sign
      *

--- a/src/main/java/net/TheDgtl/Stargate/network/portal/formatting/LegacyLineColorFormatter.java
+++ b/src/main/java/net/TheDgtl/Stargate/network/portal/formatting/LegacyLineColorFormatter.java
@@ -1,16 +1,13 @@
 package net.TheDgtl.Stargate.network.portal.formatting;
 
+import net.TheDgtl.Stargate.Stargate;
+import net.TheDgtl.Stargate.network.portal.Portal;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 
-import net.TheDgtl.Stargate.Stargate;
-import net.TheDgtl.Stargate.network.portal.Portal;
+public class LegacyLineColorFormatter extends AbstractLineColorFormatter {
 
-public class LegacyLineColorFormatter extends AbstractLineColorFormatter{
 
-   
-    
-    
     public LegacyLineColorFormatter(Material signMaterial) {
         super(signMaterial);
     }
@@ -30,7 +27,7 @@ public class LegacyLineColorFormatter extends AbstractLineColorFormatter{
     public String formatErrorLine(String error, HighlightingStyle highlightingStyle) {
         return getColor() + highlightingStyle.getHighlightedName(error);
     }
-    
+
     private ChatColor getColor() {
         return super.isLightSign ? Stargate.legacyDefaultLightSignColor : Stargate.legacyDefaultDarkSignColor;
     }

--- a/src/main/java/net/TheDgtl/Stargate/property/VersionImplemented.java
+++ b/src/main/java/net/TheDgtl/Stargate/property/VersionImplemented.java
@@ -21,7 +21,7 @@ public enum VersionImplemented {
         try {
             Class.forName(classToCheckFor);
             isImplemented = true;
-        } catch(ClassNotFoundException ignored) {
+        } catch (ClassNotFoundException ignored) {
             isImplemented = false;
         }
     }

--- a/src/main/java/net/TheDgtl/Stargate/util/GateFormatReader.java
+++ b/src/main/java/net/TheDgtl/Stargate/util/GateFormatReader.java
@@ -1,7 +1,6 @@
 package net.TheDgtl.Stargate.util;
 
 import com.cryptomorin.xseries.XMaterial;
-import net.TheDgtl.Stargate.StargateLogger;
 import net.TheDgtl.Stargate.exception.ParsingErrorException;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -16,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
-import java.util.logging.Level;
 
 /**
  * Helper class for reading gate files
@@ -40,21 +38,16 @@ public final class GateFormatReader {
      *
      * @param scanner              <p>The scanner to read from</p>
      * @param characterMaterialMap <p>The map of characters to store valid symbols in</p>
-     * @param fileName             <p>The filename of the loaded gate config file</p>
      * @param design               <p>The list to store the loaded design/layout to</p>
      * @param config               <p>The map of config values to store to</p>
-     * @param logger               <p>The logger to use for logging</p>
      * @return <p>The column count/width of the loaded gate</p>
-     * @throws ParsingErrorException 
+     * @throws ParsingErrorException  <p>If the gate file cannot be parsed</p>
      */
-    public static int readGateFile(Scanner scanner, Map<Character, Set<Material>> characterMaterialMap, String fileName,
-                                   List<List<Character>> design, Map<String, String> config,
-                                   StargateLogger logger) throws ParsingErrorException {
+    public static int readGateFile(Scanner scanner, Map<Character, Set<Material>> characterMaterialMap, 
+                                   List<List<Character>> design, Map<String, String> config) throws ParsingErrorException {
         int columns;
         try {
             columns = readGateFileContents(scanner, characterMaterialMap, design, config);
-        } catch (ParsingErrorException reThrown) {
-            throw reThrown;
         } finally {
             if (scanner != null) {
                 scanner.close();
@@ -116,8 +109,7 @@ public final class GateFormatReader {
      * @param design               <p>The list to store the loaded design/layout to</p>
      * @param config               <p>The map of config values to store to</p>
      * @return <p>The column count/width of the loaded gate</p>
-     * @throws ParsingErrorException 
-     * @throws Exception 
+     * @throws ParsingErrorException <p>If the gate file cannot be parsed</p>
      */
     private static int readGateFileContents(Scanner scanner, Map<Character, Set<Material>> characterMaterialMap,
                                             List<List<Character>> design, Map<String, String> config) throws ParsingErrorException  {
@@ -189,8 +181,7 @@ public final class GateFormatReader {
      * @param line                 <p>The line to read</p>
      * @param characterMaterialMap <p>The character to material map to store to</p>
      * @param config               <p>The config value map to store to</p>
-     * @throws ParsingErrorException 
-     * @throws Exception <p>If an invalid material is encountered</p>
+     * @throws ParsingErrorException <p>If an invalid material is encountered</p>
      */
     private static void readGateConfigValue(String line, Map<Character, Set<Material>> characterMaterialMap,
                                             Map<String, String> config) throws ParsingErrorException {

--- a/src/main/java/net/TheDgtl/Stargate/util/GateFormatReader.java
+++ b/src/main/java/net/TheDgtl/Stargate/util/GateFormatReader.java
@@ -41,9 +41,9 @@ public final class GateFormatReader {
      * @param design               <p>The list to store the loaded design/layout to</p>
      * @param config               <p>The map of config values to store to</p>
      * @return <p>The column count/width of the loaded gate</p>
-     * @throws ParsingErrorException  <p>If the gate file cannot be parsed</p>
+     * @throws ParsingErrorException <p>If the gate file cannot be parsed</p>
      */
-    public static int readGateFile(Scanner scanner, Map<Character, Set<Material>> characterMaterialMap, 
+    public static int readGateFile(Scanner scanner, Map<Character, Set<Material>> characterMaterialMap,
                                    List<List<Character>> design, Map<String, String> config) throws ParsingErrorException {
         int columns;
         try {
@@ -112,7 +112,7 @@ public final class GateFormatReader {
      * @throws ParsingErrorException <p>If the gate file cannot be parsed</p>
      */
     private static int readGateFileContents(Scanner scanner, Map<Character, Set<Material>> characterMaterialMap,
-                                            List<List<Character>> design, Map<String, String> config) throws ParsingErrorException  {
+                                            List<List<Character>> design, Map<String, String> config) throws ParsingErrorException {
         String line;
         boolean designing = false;
         int columns = 0;

--- a/src/main/java/net/TheDgtl/Stargate/util/portal/PortalCreationHelper.java
+++ b/src/main/java/net/TheDgtl/Stargate/util/portal/PortalCreationHelper.java
@@ -24,6 +24,7 @@ import net.TheDgtl.Stargate.network.portal.RealPortal;
 import net.TheDgtl.Stargate.property.BypassPermission;
 import net.TheDgtl.Stargate.util.EconomyHelper;
 import net.TheDgtl.Stargate.util.NameHelper;
+import net.TheDgtl.Stargate.util.NetworkCreationHelper;
 import net.TheDgtl.Stargate.util.SpawnDetectionHelper;
 import net.TheDgtl.Stargate.util.TranslatableMessageFormatter;
 import org.bukkit.Bukkit;
@@ -34,6 +35,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Directional;
 import org.bukkit.entity.Player;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -67,7 +69,8 @@ public final class PortalCreationHelper {
         name = NameHelper.getTrimmedName(name);
 
         if (flags.contains(PortalFlag.BUNGEE)) {
-            return new BungeePortal(name, destination, targetServer, flags, gate, ownerUUID, logger);
+            Network bungeeNetwork = NetworkCreationHelper.selectNetwork(BungeePortal.getLegacyNetworkName(), new HashSet<>());
+            return new BungeePortal(bungeeNetwork, name, destination, targetServer, flags, gate, ownerUUID, logger);
         } else if (flags.contains(PortalFlag.RANDOM)) {
             return new RandomPortal(network, name, flags, gate, ownerUUID, logger);
         } else if (flags.contains(PortalFlag.NETWORKED)) {

--- a/src/main/java/net/TheDgtl/Stargate/util/portal/PortalCreationHelper.java
+++ b/src/main/java/net/TheDgtl/Stargate/util/portal/PortalCreationHelper.java
@@ -67,7 +67,7 @@ public final class PortalCreationHelper {
         name = NameHelper.getTrimmedName(name);
 
         if (flags.contains(PortalFlag.BUNGEE)) {
-            return new BungeePortal(network, name, destination, targetServer, flags, gate, ownerUUID, logger);
+            return new BungeePortal(name, destination, targetServer, flags, gate, ownerUUID, logger);
         } else if (flags.contains(PortalFlag.RANDOM)) {
             return new RandomPortal(network, name, flags, gate, ownerUUID, logger);
         } else if (flags.contains(PortalFlag.NETWORKED)) {

--- a/src/main/java/net/TheDgtl/Stargate/util/portal/PortalPermissionHelper.java
+++ b/src/main/java/net/TheDgtl/Stargate/util/portal/PortalPermissionHelper.java
@@ -180,6 +180,15 @@ public final class PortalPermissionHelper {
         if (portal.getNetwork().getName().equals(ConfigurationHelper.getString(ConfigurationOption.DEFAULT_NETWORK))) {
             return permissionIdentifier + ".network.default";
         }
+        if (portal.getNetwork().getName().equals(ConfigurationHelper.getStringOrDefault(
+                ConfigurationOption.LEGACY_BUNGEE_NETWORK))) {
+            if (!portal.hasFlag(PortalFlag.BUNGEE)) {
+                //A creation of a non-bungee portal on the legacy bungee network should never be allowed
+                return "r5j4k2l4l7o9l7.j5k6k6k3kf03kv";
+            } else {
+                return null;
+            }
+        }
         return generateCustomNetworkPermission(permissionIdentifier, portal.getNetwork().getName());
     }
 


### PR DESCRIPTION
This change forces all legacy BungeeCord portals to be created on the legacy network.
This change also skips the code trying to make sense of the server name when creating a new legacy BungeeCord portal using a sign.
Random instances of the legacy network name have been changed to get it from the BungeePortal class.
This should fix some of the problems of #166, though the legacy network could use a new name.