### PR TITLE
End portal fix

### DIFF
--- a/src/main/java/net/TheDgtl/Stargate/Stargate.java
+++ b/src/main/java/net/TheDgtl/Stargate/Stargate.java
@@ -37,6 +37,7 @@ import net.TheDgtl.Stargate.formatting.StargateLanguageManager;
 import net.TheDgtl.Stargate.gate.GateFormat;
 import net.TheDgtl.Stargate.gate.GateFormatHandler;
 import net.TheDgtl.Stargate.listener.BlockEventListener;
+import net.TheDgtl.Stargate.listener.EntityInsideBlockEventListener;
 import net.TheDgtl.Stargate.listener.MoveEventListener;
 import net.TheDgtl.Stargate.listener.PlayerAdvancementListener;
 import net.TheDgtl.Stargate.listener.PlayerEventListener;
@@ -393,6 +394,9 @@ public class Stargate extends JavaPlugin implements StargateLogger, StargateAPI,
         pluginManager.registerEvents(new PluginEventListener(), this);
         if (NonLegacyMethod.PLAYER_ADVANCEMENT_CRITERION_EVENT.isImplemented()) {
             pluginManager.registerEvents(new PlayerAdvancementListener(), this);
+        }
+        if (NonLegacyMethod.ENTITY_INSIDE_BLOCK_EVENT.isImplemented()) {
+            pluginManager.registerEvents(new EntityInsideBlockEventListener(), this);
         }
     }
 

--- a/src/main/java/net/TheDgtl/Stargate/listener/EntityInsideBlockEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/EntityInsideBlockEventListener.java
@@ -1,0 +1,24 @@
+package net.TheDgtl.Stargate.listener;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import io.papermc.paper.event.entity.EntityInsideBlockEvent;
+import net.TheDgtl.Stargate.Stargate;
+import net.TheDgtl.Stargate.gate.structure.GateStructureType;
+
+
+public class EntityInsideBlockEventListener implements Listener{
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    void onEntityInsideBlock(EntityInsideBlockEvent event) {
+        Block block = event.getBlock();
+        if ((block.getType() != Material.END_PORTAL && block.getType() != Material.NETHER_PORTAL)
+                || Stargate.getRegistryStatic().getPortal(block.getLocation(), GateStructureType.IRIS) == null) {
+            return;
+        }
+        event.setCancelled(true);
+    }
+}

--- a/src/main/java/net/TheDgtl/Stargate/listener/EntityInsideBlockEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/EntityInsideBlockEventListener.java
@@ -1,24 +1,35 @@
 package net.TheDgtl.Stargate.listener;
 
+import io.papermc.paper.event.entity.EntityInsideBlockEvent;
+import net.TheDgtl.Stargate.Stargate;
+import net.TheDgtl.Stargate.gate.structure.GateStructureType;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import io.papermc.paper.event.entity.EntityInsideBlockEvent;
-import net.TheDgtl.Stargate.Stargate;
-import net.TheDgtl.Stargate.gate.structure.GateStructureType;
+/**
+ * A listener specifically for the Paper-only EntityInsideBlockEvent event
+ */
+public class EntityInsideBlockEventListener implements Listener {
 
-
-public class EntityInsideBlockEventListener implements Listener{
+    /**
+     * Listens for the entity inside block event and cancels it if it's caused by a player entering a Stargate
+     *
+     * <p>NOTE: This has to be in a separate listener, as it'll otherwise brick other listeners when not running on a
+     * paper instance</p>
+     *
+     * @param event <p>The triggered event</p>
+     */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     void onEntityInsideBlock(EntityInsideBlockEvent event) {
         Block block = event.getBlock();
-        if ((block.getType() != Material.END_PORTAL && block.getType() != Material.NETHER_PORTAL)
-                || Stargate.getRegistryStatic().getPortal(block.getLocation(), GateStructureType.IRIS) == null) {
-            return;
+        //Block any results of entering a default portal block
+        if ((block.getType() == Material.END_PORTAL || block.getType() == Material.NETHER_PORTAL) &&
+                Stargate.getRegistryStatic().getPortal(block.getLocation(), GateStructureType.IRIS) == null) {
+            event.setCancelled(true);
         }
-        event.setCancelled(true);
     }
+
 }

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -133,16 +133,21 @@ public class MoveEventListener implements Listener {
      * @return <p>The first found adjacent Stargate using END_PORTAL, or null</p>
      */
     private RealPortal getAdjacentEndPortalStargate(Location fromLocation, Location toLocation) {
-        List<Location> relevantLocations = getRelevantAdjacentLocations(fromLocation, toLocation);
+        Vector velocity = toLocation.toVector().subtract(fromLocation.toVector());
+        List<Location> relevantLocations = getRelevantAdjacentLocations(fromLocation, toLocation, velocity);
         for (Location headingTo : relevantLocations) {
             RealPortal possiblePortal = Stargate.getRegistryStatic().getPortal(headingTo, GateStructureType.IRIS);
             if (possiblePortal != null &&
                     possiblePortal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
                 Location middle = new Location(headingTo.getWorld(), headingTo.getBlockX() + 0.5,
                         headingTo.getBlockY() + 0.5, headingTo.getBlockZ() + 0.5);
-                if (Math.abs(middle.getX() - toLocation.getX()) < 0.6 ||
-                        Math.abs(middle.getY() - toLocation.getY()) < 0.6 ||
-                        Math.abs(middle.getZ() - toLocation.getZ()) < 0.6) {
+                double xMargin = 0.6 + Math.abs(velocity.getX());
+                double yMargin = 0.6 + Math.abs(velocity.getY());
+                double zMargin = 0.6 + Math.abs(velocity.getBlockZ());
+
+                if (Math.abs(middle.getX() - toLocation.getX()) < xMargin ||
+                        Math.abs(middle.getY() - toLocation.getY()) < yMargin ||
+                        Math.abs(middle.getZ() - toLocation.getZ()) < zMargin) {
                     return possiblePortal;
                 }
             }
@@ -157,10 +162,10 @@ public class MoveEventListener implements Listener {
      * @param toLocation   <p>The location the target moved to</p>
      * @return <p>The relevant adjacent locations</p>
      */
-    private List<Location> getRelevantAdjacentLocations(Location fromLocation, Location toLocation) {
+    private List<Location> getRelevantAdjacentLocations(Location fromLocation, Location toLocation, Vector velocity) {
         List<Location> relevantLocations = new ArrayList<>();
         Vector zeroVector = new Vector();
-        Vector targetVelocity = normalizeVelocity(toLocation.toVector().subtract(fromLocation.toVector()));
+        Vector targetVelocity = normalizeVelocity(velocity);
 
         //Calculate all relevant vectors that might point to end portal Stargates
         Set<Vector> relevantVectors = new HashSet<>();

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -2,8 +2,9 @@ package net.TheDgtl.Stargate.listener;
 
 import net.TheDgtl.Stargate.Stargate;
 import net.TheDgtl.Stargate.gate.structure.GateStructureType;
-import net.TheDgtl.Stargate.network.portal.Portal;
+import net.TheDgtl.Stargate.network.portal.RealPortal;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
@@ -16,6 +17,8 @@ import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 
 /**
@@ -23,8 +26,8 @@ import java.util.logging.Level;
  */
 public class MoveEventListener implements Listener {
 
-    private static PlayerTeleportEvent.TeleportCause[] causesToCheck = { PlayerTeleportEvent.TeleportCause.END_GATEWAY,
-            PlayerTeleportEvent.TeleportCause.END_PORTAL, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL };
+    private static final PlayerTeleportEvent.TeleportCause[] causesToCheck = {PlayerTeleportEvent.TeleportCause.END_GATEWAY,
+            PlayerTeleportEvent.TeleportCause.END_PORTAL, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL};
 
     /**
      * Listens for and cancels any default vehicle portal events caused by stargates
@@ -47,12 +50,12 @@ public class MoveEventListener implements Listener {
     public void onPlayerTeleport(@NotNull PlayerTeleportEvent event) {
         World world = event.getFrom().getWorld();
         PlayerTeleportEvent.TeleportCause cause = event.getCause();
-        if (cause == PlayerTeleportEvent.TeleportCause.END_GATEWAY && ( world == null ||
-                world.getEnvironment() != World.Environment.THE_END)){
+        if (cause == PlayerTeleportEvent.TeleportCause.END_GATEWAY && (world == null ||
+                world.getEnvironment() != World.Environment.THE_END)) {
             return;
         }
         for (PlayerTeleportEvent.TeleportCause causeToCheck : causesToCheck) {
-            if(cause != causeToCheck) {
+            if (cause != causeToCheck) {
                 continue;
             }
             if (Stargate.getRegistryStatic().isNextToPortal(event.getFrom(), GateStructureType.IRIS)
@@ -62,7 +65,7 @@ public class MoveEventListener implements Listener {
             }
         }
     }
-    
+
 
     /**
      * Listens for any player movement and teleports the player if entering a stargate
@@ -92,15 +95,56 @@ public class MoveEventListener implements Listener {
      * @param fromLocation <p>The location the target moved from</p>
      */
     private void onAnyMove(Entity target, Location toLocation, Location fromLocation) {
+        RealPortal portal = null;
+        if (toLocation != null && toLocation.getWorld() != null &&
+                toLocation.getWorld().getEnvironment() == World.Environment.THE_END) {
+            List<Location> relevantLocations = new ArrayList<>();
+            Vector targetVelocity = normalizeVelocity(target.getVelocity());
+            if (targetVelocity.getX() != 0 && targetVelocity.getY() != 0 && targetVelocity.getZ() != 0) {
+                relevantLocations.add(toLocation.clone().add(targetVelocity));
+            }
+            if (targetVelocity.getX() != 0 && targetVelocity.getZ() != 0) {
+                relevantLocations.add(toLocation.clone().add(new Vector(targetVelocity.getX(), 0, targetVelocity.getZ())));
+            }
+            if (targetVelocity.getX() != 0 && targetVelocity.getY() != 0) {
+                relevantLocations.add(toLocation.clone().add(new Vector(targetVelocity.getX(), targetVelocity.getY(), 0)));
+            }
+            if (targetVelocity.getZ() != 0 && targetVelocity.getY() != 0) {
+                relevantLocations.add(toLocation.clone().add(new Vector(0, targetVelocity.getY(), targetVelocity.getZ())));
+            }
+            if (targetVelocity.getX() != 0) {
+                relevantLocations.add(toLocation.clone().add(new Vector(targetVelocity.getX(), 0, 0)));
+            }
+            if (targetVelocity.getY() != 0) {
+                relevantLocations.add(toLocation.clone().add(new Vector(0, targetVelocity.getY(), 0)));
+            }
+            if (targetVelocity.getZ() != 0) {
+                relevantLocations.add(toLocation.clone().add(new Vector(0, 0, targetVelocity.getZ())));
+            }
+            for (Location headingTo : relevantLocations) {
+                portal = Stargate.getRegistryStatic().getPortal(headingTo, GateStructureType.IRIS);
+                if (portal != null && portal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
+                    Location middle = new Location(headingTo.getWorld(), headingTo.getBlockX() + 0.5,
+                            headingTo.getBlockY() + 0.5, headingTo.getBlockZ() + 0.5);
+                    if (Math.abs(middle.getX() - toLocation.getX()) < 0.6 ||
+                            Math.abs(middle.getY() - toLocation.getY()) < 0.6 ||
+                            Math.abs(middle.getZ() - toLocation.getZ()) < 0.6) {
+                        break;
+                    }
+                }
+            }
+        }
+
         // Check if entity moved one block (its only possible to have entered a portal if that's the case)
-        if (toLocation == null ||
-                fromLocation.getBlockX() == toLocation.getBlockX() &&
-                        fromLocation.getBlockY() == toLocation.getBlockY() &&
-                        fromLocation.getBlockZ() == toLocation.getBlockZ()) {
+        if (toLocation == null || portal == null && fromLocation.getBlockX() == toLocation.getBlockX() &&
+                fromLocation.getBlockY() == toLocation.getBlockY() &&
+                fromLocation.getBlockZ() == toLocation.getBlockZ()) {
             return;
         }
 
-        Portal portal = Stargate.getRegistryStatic().getPortal(toLocation, GateStructureType.IRIS);
+        if (portal == null) {
+            portal = Stargate.getRegistryStatic().getPortal(toLocation, GateStructureType.IRIS);
+        }
         if (portal == null || !portal.isOpen()) {
             return;
         }
@@ -111,6 +155,17 @@ public class MoveEventListener implements Listener {
         Stargate.log(Level.FINER, "Trying to teleport entity, initial velocity: " + target.getVelocity() +
                 ", new velocity: " + newVelocity);
         portal.doTeleport(target);
+    }
+
+    /**
+     * Normalizes the input velocity to a vector of length 1 or 0 in any direction (though the max length of the entire vector is sqrt(2))
+     */
+    private Vector normalizeVelocity(Vector velocity) {
+        Vector normalizedVector = new Vector(0, 0, 0);
+        normalizedVector = normalizedVector.setX(velocity.getX() < 0 ? -1 : (velocity.getX() > 0 ? 1 : 0));
+        normalizedVector = normalizedVector.setZ(velocity.getZ() < 0 ? -1 : (velocity.getZ() > 0 ? 1 : 0));
+        normalizedVector = normalizedVector.setY(velocity.getY() < 0 ? -1 : (velocity.getY() > 0 ? 1 : 0));
+        return normalizedVector;
     }
 
 }

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -18,7 +18,9 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -98,43 +100,7 @@ public class MoveEventListener implements Listener {
         RealPortal portal = null;
         if (toLocation != null && toLocation.getWorld() != null &&
                 toLocation.getWorld().getEnvironment() == World.Environment.THE_END) {
-            List<Location> relevantLocations = new ArrayList<>();
-            Vector targetVelocity = normalizeVelocity(toLocation.toVector().subtract(fromLocation.toVector()));
-            if (targetVelocity.getX() != 0 && targetVelocity.getY() != 0 && targetVelocity.getZ() != 0) {
-                relevantLocations.add(toLocation.clone().add(targetVelocity));
-            }
-            if (targetVelocity.getX() != 0 && targetVelocity.getZ() != 0) {
-                relevantLocations.add(toLocation.clone().add(new Vector(targetVelocity.getX(), 0, targetVelocity.getZ())));
-            }
-            if (targetVelocity.getX() != 0 && targetVelocity.getY() != 0) {
-                relevantLocations.add(toLocation.clone().add(new Vector(targetVelocity.getX(), targetVelocity.getY(), 0)));
-            }
-            if (targetVelocity.getZ() != 0 && targetVelocity.getY() != 0) {
-                relevantLocations.add(toLocation.clone().add(new Vector(0, targetVelocity.getY(), targetVelocity.getZ())));
-            }
-            if (targetVelocity.getX() != 0) {
-                relevantLocations.add(toLocation.clone().add(new Vector(targetVelocity.getX(), 0, 0)));
-            }
-            if (targetVelocity.getY() != 0) {
-                relevantLocations.add(toLocation.clone().add(new Vector(0, targetVelocity.getY(), 0)));
-            }
-            if (targetVelocity.getZ() != 0) {
-                relevantLocations.add(toLocation.clone().add(new Vector(0, 0, targetVelocity.getZ())));
-            }
-            for (Location headingTo : relevantLocations) {
-                RealPortal possiblePortal = Stargate.getRegistryStatic().getPortal(headingTo, GateStructureType.IRIS);
-                if (possiblePortal != null && 
-                        possiblePortal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
-                    Location middle = new Location(headingTo.getWorld(), headingTo.getBlockX() + 0.5,
-                            headingTo.getBlockY() + 0.5, headingTo.getBlockZ() + 0.5);
-                    if (Math.abs(middle.getX() - toLocation.getX()) < 0.6 ||
-                            Math.abs(middle.getY() - toLocation.getY()) < 0.6 ||
-                            Math.abs(middle.getZ() - toLocation.getZ()) < 0.6) {
-                        portal = possiblePortal;
-                        break;
-                    }
-                }
-            }
+            portal = getAdjacentEndPortalStargate(fromLocation, toLocation);
         }
 
         // Check if entity moved one block (its only possible to have entered a portal if that's the case)
@@ -157,6 +123,66 @@ public class MoveEventListener implements Listener {
         Stargate.log(Level.FINER, "Trying to teleport entity, initial velocity: " + target.getVelocity() +
                 ", new velocity: " + newVelocity);
         portal.doTeleport(target);
+    }
+
+    /**
+     * Gets the first adjacent Stargate using END_PORTAL as iris, if any
+     *
+     * @param fromLocation <p>The location the target moved from</p>
+     * @param toLocation   <p>The location the target moved to</p>
+     * @return <p>The first found adjacent Stargate using END_PORTAL, or null</p>
+     */
+    private RealPortal getAdjacentEndPortalStargate(Location fromLocation, Location toLocation) {
+        List<Location> relevantLocations = getRelevantAdjacentLocations(fromLocation, toLocation);
+        for (Location headingTo : relevantLocations) {
+            RealPortal possiblePortal = Stargate.getRegistryStatic().getPortal(headingTo, GateStructureType.IRIS);
+            if (possiblePortal != null &&
+                    possiblePortal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
+                Location middle = new Location(headingTo.getWorld(), headingTo.getBlockX() + 0.5,
+                        headingTo.getBlockY() + 0.5, headingTo.getBlockZ() + 0.5);
+                if (Math.abs(middle.getX() - toLocation.getX()) < 0.6 ||
+                        Math.abs(middle.getY() - toLocation.getY()) < 0.6 ||
+                        Math.abs(middle.getZ() - toLocation.getZ()) < 0.6) {
+                    return possiblePortal;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets the adjacent locations relevant for END_PORTAL checking based on the given movement
+     *
+     * @param fromLocation <p>The location the target moved from</p>
+     * @param toLocation   <p>The location the target moved to</p>
+     * @return <p>The relevant adjacent locations</p>
+     */
+    private List<Location> getRelevantAdjacentLocations(Location fromLocation, Location toLocation) {
+        List<Location> relevantLocations = new ArrayList<>();
+        Vector zeroVector = new Vector();
+        Vector targetVelocity = normalizeVelocity(toLocation.toVector().subtract(fromLocation.toVector()));
+
+        //Calculate all relevant vectors that might point to end portal Stargates
+        Set<Vector> relevantVectors = new HashSet<>();
+        Vector xVector = new Vector(targetVelocity.getX(), 0, 0);
+        Vector yVector = new Vector(0, targetVelocity.getY(), 0);
+        Vector zVector = new Vector(0, 0, targetVelocity.getZ());
+        relevantVectors.add(xVector.clone());
+        relevantVectors.add(yVector.clone());
+        relevantVectors.add(zVector.clone());
+        relevantVectors.add(xVector.clone().add(yVector));
+        relevantVectors.add(xVector.clone().add(zVector));
+        relevantVectors.add(yVector.clone().add(zVector));
+        relevantVectors.add(yVector.clone().add(zVector).add(xVector));
+
+        //Calculate the locations resulting from the relevant block vectors
+        relevantVectors.forEach(relevantVector -> {
+            //It's not necessary to check the actual target block
+            if (!relevantVector.equals(zeroVector)) {
+                relevantLocations.add(toLocation.clone().add(relevantVector));
+            }
+        });
+        return relevantLocations;
     }
 
     /**

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -170,15 +170,15 @@ public class MoveEventListener implements Listener {
                         Math.abs(velocity.getZ()) > speedThreshold;
                 BlockFace facing = possiblePortal.getGate().getFacing();
                 boolean followsZAxis = facing == BlockFace.SOUTH || facing == BlockFace.NORTH;
-                boolean nearX = !followsZAxis && Math.abs(middle.getX() - toLocation.getX()) < margin;
+                boolean nearX = Math.abs(middle.getX() - toLocation.getX()) < margin;
                 boolean nearY = Math.abs(middle.getY() - toLocation.getY()) < yMargin;
-                boolean nearZ = followsZAxis && Math.abs(middle.getZ() - toLocation.getZ()) < margin;
+                boolean nearZ = Math.abs(middle.getZ() - toLocation.getZ()) < margin;
                 Stargate.log(Level.FINEST, "Hit-box detection:");
                 Stargate.log(Level.FINEST, "Over speed threshold: " + overSpeedThreshold);
                 Stargate.log(Level.FINEST, "Near X: " + nearX);
                 Stargate.log(Level.FINEST, "Near Y: " + nearY);
                 Stargate.log(Level.FINEST, "Near Z: " + nearZ);
-                if (overSpeedThreshold || ((nearX || nearZ) && nearY)) {
+                if (overSpeedThreshold || (((nearX && !followsZAxis) || (nearZ && followsZAxis)) && nearY)) {
                     Stargate.log(Level.FINEST, "Player is entering END_PORTAL Stargate");
                     return possiblePortal;
                 }
@@ -209,9 +209,7 @@ public class MoveEventListener implements Listener {
         relevantVectors.add(yVector.clone());
         relevantVectors.add(zVector.clone());
         relevantVectors.add(xVector.clone().add(yVector));
-        relevantVectors.add(xVector.clone().add(zVector));
         relevantVectors.add(yVector.clone().add(zVector));
-        relevantVectors.add(yVector.clone().add(zVector).add(xVector));
 
         //Calculate the locations resulting from the relevant block vectors
         relevantVectors.forEach(relevantVector -> {

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -141,10 +141,10 @@ public class MoveEventListener implements Listener {
                     possiblePortal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
                 Location middle = new Location(headingTo.getWorld(), headingTo.getBlockX() + 0.5,
                         headingTo.getBlockY() + 0.5, headingTo.getBlockZ() + 0.5);
-                
+
                 double margin = 1.01;
                 if (Math.abs(middle.getX() - toLocation.getX()) < margin &&
-                        Math.abs(middle.getY() - toLocation.getY()) < 1.5 &&
+                        Math.abs(middle.getY() - toLocation.getY()) < 0.5 &&
                         Math.abs(middle.getZ() - toLocation.getZ()) < margin) {
                     return possiblePortal;
                 }
@@ -156,8 +156,8 @@ public class MoveEventListener implements Listener {
     /**
      * Gets the adjacent locations relevant for END_PORTAL checking based on the given movement
      *
-     * @param toLocation   <p>The location the target moved to</p>
-     * @param velocity  <p>The velocity of the moving entity</p>
+     * @param toLocation <p>The location the target moved to</p>
+     * @param velocity   <p>The velocity of the moving entity</p>
      * @return <p>The relevant adjacent locations</p>
      */
     private List<Location> getRelevantAdjacentLocations(Location toLocation, Vector velocity) {

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -99,7 +99,7 @@ public class MoveEventListener implements Listener {
         if (toLocation != null && toLocation.getWorld() != null &&
                 toLocation.getWorld().getEnvironment() == World.Environment.THE_END) {
             List<Location> relevantLocations = new ArrayList<>();
-            Vector targetVelocity = normalizeVelocity(target.getVelocity());
+            Vector targetVelocity = normalizeVelocity(toLocation.toVector().subtract(fromLocation.toVector()));
             if (targetVelocity.getX() != 0 && targetVelocity.getY() != 0 && targetVelocity.getZ() != 0) {
                 relevantLocations.add(toLocation.clone().add(targetVelocity));
             }

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -122,13 +122,15 @@ public class MoveEventListener implements Listener {
                 relevantLocations.add(toLocation.clone().add(new Vector(0, 0, targetVelocity.getZ())));
             }
             for (Location headingTo : relevantLocations) {
-                portal = Stargate.getRegistryStatic().getPortal(headingTo, GateStructureType.IRIS);
-                if (portal != null && portal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
+                RealPortal possiblePortal = Stargate.getRegistryStatic().getPortal(headingTo, GateStructureType.IRIS);
+                if (possiblePortal != null && 
+                        possiblePortal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
                     Location middle = new Location(headingTo.getWorld(), headingTo.getBlockX() + 0.5,
                             headingTo.getBlockY() + 0.5, headingTo.getBlockZ() + 0.5);
                     if (Math.abs(middle.getX() - toLocation.getX()) < 0.6 ||
                             Math.abs(middle.getY() - toLocation.getY()) < 0.6 ||
                             Math.abs(middle.getZ() - toLocation.getZ()) < 0.6) {
+                        portal = possiblePortal;
                         break;
                     }
                 }

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -134,20 +134,18 @@ public class MoveEventListener implements Listener {
      */
     private RealPortal getAdjacentEndPortalStargate(Location fromLocation, Location toLocation) {
         Vector velocity = toLocation.toVector().subtract(fromLocation.toVector());
-        List<Location> relevantLocations = getRelevantAdjacentLocations(fromLocation, toLocation, velocity);
+        List<Location> relevantLocations = getRelevantAdjacentLocations(toLocation, velocity);
         for (Location headingTo : relevantLocations) {
             RealPortal possiblePortal = Stargate.getRegistryStatic().getPortal(headingTo, GateStructureType.IRIS);
             if (possiblePortal != null &&
                     possiblePortal.getGate().getFormat().getIrisMaterial(true) == Material.END_PORTAL) {
                 Location middle = new Location(headingTo.getWorld(), headingTo.getBlockX() + 0.5,
                         headingTo.getBlockY() + 0.5, headingTo.getBlockZ() + 0.5);
-                double xMargin = 0.6 + Math.abs(velocity.getX());
-                double yMargin = 0.6 + Math.abs(velocity.getY());
-                double zMargin = 0.6 + Math.abs(velocity.getBlockZ());
-
-                if (Math.abs(middle.getX() - toLocation.getX()) < xMargin ||
-                        Math.abs(middle.getY() - toLocation.getY()) < yMargin ||
-                        Math.abs(middle.getZ() - toLocation.getZ()) < zMargin) {
+                
+                double margin = 1.01;
+                if (Math.abs(middle.getX() - toLocation.getX()) < margin &&
+                        Math.abs(middle.getY() - toLocation.getY()) < 1.5 &&
+                        Math.abs(middle.getZ() - toLocation.getZ()) < margin) {
                     return possiblePortal;
                 }
             }
@@ -158,11 +156,11 @@ public class MoveEventListener implements Listener {
     /**
      * Gets the adjacent locations relevant for END_PORTAL checking based on the given movement
      *
-     * @param fromLocation <p>The location the target moved from</p>
      * @param toLocation   <p>The location the target moved to</p>
+     * @param velocity  <p>The velocity of the moving entity</p>
      * @return <p>The relevant adjacent locations</p>
      */
-    private List<Location> getRelevantAdjacentLocations(Location fromLocation, Location toLocation, Vector velocity) {
+    private List<Location> getRelevantAdjacentLocations(Location toLocation, Vector velocity) {
         List<Location> relevantLocations = new ArrayList<>();
         Vector zeroVector = new Vector();
         Vector targetVelocity = normalizeVelocity(velocity);

--- a/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/MoveEventListener.java
@@ -7,6 +7,7 @@ import net.TheDgtl.Stargate.network.portal.TeleportedEntityRelationDFS;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -167,15 +168,17 @@ public class MoveEventListener implements Listener {
                 double speedThreshold = 0.5;
                 boolean overSpeedThreshold = Math.abs(velocity.getX()) > speedThreshold ||
                         Math.abs(velocity.getZ()) > speedThreshold;
-                boolean nearX = Math.abs(middle.getX() - toLocation.getX()) < margin;
+                BlockFace facing = possiblePortal.getGate().getFacing();
+                boolean followsZAxis = facing == BlockFace.SOUTH || facing == BlockFace.NORTH;
+                boolean nearX = !followsZAxis && Math.abs(middle.getX() - toLocation.getX()) < margin;
                 boolean nearY = Math.abs(middle.getY() - toLocation.getY()) < yMargin;
-                boolean nearZ = Math.abs(middle.getZ() - toLocation.getZ()) < margin;
+                boolean nearZ = followsZAxis && Math.abs(middle.getZ() - toLocation.getZ()) < margin;
                 Stargate.log(Level.FINEST, "Hit-box detection:");
                 Stargate.log(Level.FINEST, "Over speed threshold: " + overSpeedThreshold);
                 Stargate.log(Level.FINEST, "Near X: " + nearX);
                 Stargate.log(Level.FINEST, "Near Y: " + nearY);
                 Stargate.log(Level.FINEST, "Near Z: " + nearZ);
-                if (overSpeedThreshold || (nearX && nearY && nearZ)) {
+                if (overSpeedThreshold || ((nearX || nearZ) && nearY)) {
                     Stargate.log(Level.FINEST, "Player is entering END_PORTAL Stargate");
                     return possiblePortal;
                 }

--- a/src/main/java/net/TheDgtl/Stargate/listener/PlayerAdvancementListener.java
+++ b/src/main/java/net/TheDgtl/Stargate/listener/PlayerAdvancementListener.java
@@ -6,21 +6,25 @@ import net.TheDgtl.Stargate.gate.structure.GateStructureType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
+/**
+ * A listener for the PlayerAdvancementCriterionEvent event
+ */
 public class PlayerAdvancementListener implements Listener {
+
     /**
      * Listen to player advancement events, and cancel if the advancement came from touching a generated portal block
-     * <p>
-     * NOTE: This have to be in a separate listener, as it's brick other listeners when not running on a paper instance
      *
-     * @param event
+     * <p>NOTE: This has to be in a separate listener, as it'll otherwise brick other listeners when not running on a
+     * paper instance</p>
+     *
+     * @param event <p>The triggered event</p>
      */
     @EventHandler
     public void onPlayerAdvancementCriterionGrant(PlayerAdvancementCriterionGrantEvent event) {
-        if (!event.getCriterion().equals("entered_end_gateway") || !Stargate.getRegistryStatic()
-                .isNextToPortal(event.getPlayer().getLocation(), GateStructureType.IRIS)) {
-            return;
+        if (event.getCriterion().equals("entered_end_gateway") &&
+                Stargate.getRegistryStatic().isNextToPortal(event.getPlayer().getLocation(), GateStructureType.IRIS)) {
+            event.setCancelled(true);
         }
-        event.setCancelled(true);
-
     }
+
 }

--- a/src/main/java/net/TheDgtl/Stargate/migration/DataMigration_1_0_0.java
+++ b/src/main/java/net/TheDgtl/Stargate/migration/DataMigration_1_0_0.java
@@ -86,7 +86,7 @@ public class DataMigration_1_0_0 extends DataMigration {
                     break;
                 }
             }
-            if(portalFolderValue != null) {
+            if (portalFolderValue != null) {
                 moveFilesToDebugDirectory(portalFolderValue);
             }
         } catch (IOException | InvalidStructureException | NameErrorException e) {
@@ -163,7 +163,7 @@ public class DataMigration_1_0_0 extends DataMigration {
             directory.delete();
         }
     }
-    
+
     /**
      * Loads the configuration conversions used to load legacy configuration files
      */

--- a/src/main/java/net/TheDgtl/Stargate/network/portal/NetworkedPortal.java
+++ b/src/main/java/net/TheDgtl/Stargate/network/portal/NetworkedPortal.java
@@ -154,7 +154,7 @@ public class NetworkedPortal extends AbstractPortal {
 
     @Override
     public void close(boolean force) {
-        if ((hasFlag(PortalFlag.ALWAYS_ON) && !force ) || super.isDestroyed || !super.isOpen()) {
+        if ((hasFlag(PortalFlag.ALWAYS_ON) && !force) || super.isDestroyed || !super.isOpen()) {
             return;
         }
         super.close(force);

--- a/src/main/java/net/TheDgtl/Stargate/property/NonLegacyMethod.java
+++ b/src/main/java/net/TheDgtl/Stargate/property/NonLegacyMethod.java
@@ -51,7 +51,14 @@ public enum NonLegacyMethod {
      *
      * <p> PlayerAdvancementCriterionGrantEvent was added to enable cancelling advancements </p>
      */
-    PLAYER_ADVANCEMENT_CRITERION_EVENT("com.destroystokyo.paper.event.player.PlayerAdvancementCriterionGrantEvent", "getPlayer");
+    PLAYER_ADVANCEMENT_CRITERION_EVENT("com.destroystokyo.paper.event.player.PlayerAdvancementCriterionGrantEvent", "getPlayer"),
+    
+    /**
+     * The paper EntityInsideBlockEven getBlock() method
+     * 
+     * <p> EntityInsideBlockEvent was added to allow cancelling certain blocks from getting triggered by entities </p>
+     */
+    ENTITY_INSIDE_BLOCK_EVENT("io.papermc.paper.event.entity.EntityInsideBlockEvent","getBlock");
 
     private String classToCheckFor;
     private String methodInClassToCheckFor;

--- a/src/main/java/net/TheDgtl/Stargate/property/NonLegacyMethod.java
+++ b/src/main/java/net/TheDgtl/Stargate/property/NonLegacyMethod.java
@@ -52,13 +52,13 @@ public enum NonLegacyMethod {
      * <p> PlayerAdvancementCriterionGrantEvent was added to enable cancelling advancements </p>
      */
     PLAYER_ADVANCEMENT_CRITERION_EVENT("com.destroystokyo.paper.event.player.PlayerAdvancementCriterionGrantEvent", "getPlayer"),
-    
+
     /**
      * The paper EntityInsideBlockEven getBlock() method
-     * 
+     *
      * <p> EntityInsideBlockEvent was added to allow cancelling certain blocks from getting triggered by entities </p>
      */
-    ENTITY_INSIDE_BLOCK_EVENT("io.papermc.paper.event.entity.EntityInsideBlockEvent","getBlock");
+    ENTITY_INSIDE_BLOCK_EVENT("io.papermc.paper.event.entity.EntityInsideBlockEvent", "getBlock");
 
     private String classToCheckFor;
     private String methodInClassToCheckFor;


### PR DESCRIPTION
Adds a fix for END_PORTAL Stargates

This is a combination of two fixes. One is Paper-only, but should be foolproof. The other is basically to create an artificial hitbox outside the END_PORTAL's normal hitbox and teleporting the player away before the END_PORTAL's teleportation can trigger.