### PR TITLE
Add SQL statements for MySQL, fix #369

### DIFF
--- a/src/main/resources/database/mysql-queries/CREATE_TABLE_INTER_PORTAL_POSITION.sql
+++ b/src/main/resources/database/mysql-queries/CREATE_TABLE_INTER_PORTAL_POSITION.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS {InterPortalPosition}
+(
+   portalName NVARCHAR (180) NOT NULL,
+   networkName NVARCHAR (180) NOT NULL,
+   xCoordinate INTEGER NOT NULL,
+   yCoordinate INTEGER NOT NULL,
+   zCoordinate INTEGER NOT NULL,
+   positionType INTEGER NOT NULL,
+   metaData TEXT,
+   pluginName VARCHAR(255) DEFAULT 'Stargate',
+   PRIMARY KEY
+   (
+      portalName,
+      networkName,
+      xCoordinate,
+      yCoordinate,
+      zCoordinate
+   ),
+   FOREIGN KEY
+   (
+      portalName,
+      networkName
+   )
+   REFERENCES {InterPortal}
+   (
+      name,
+      network
+   )
+   ON UPDATE CASCADE,
+   FOREIGN KEY (positionType) REFERENCES {PositionType} (id)
+);

--- a/src/main/resources/database/mysql-queries/CREATE_TABLE_PORTAL_POSITION.sql
+++ b/src/main/resources/database/mysql-queries/CREATE_TABLE_PORTAL_POSITION.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS {PortalPosition}
+(
+   portalName NVARCHAR (180) NOT NULL,
+   networkName NVARCHAR (180) NOT NULL,
+   xCoordinate INTEGER NOT NULL,
+   yCoordinate INTEGER NOT NULL,
+   zCoordinate INTEGER NOT NULL,
+   positionType INTEGER NOT NULL,
+   metaData TEXT,
+   pluginName VARCHAR(255) DEFAULT 'Stargate',
+   PRIMARY KEY
+   (
+      portalName,
+      networkName,
+      xCoordinate,
+      yCoordinate,
+      zCoordinate
+   ),
+   FOREIGN KEY
+   (
+      portalName,
+      networkName
+   )
+   REFERENCES {Portal}
+   (
+      name,
+      network
+   )
+   ON UPDATE CASCADE,
+   FOREIGN KEY (positionType) REFERENCES {PositionType} (id)
+);


### PR DESCRIPTION
This PR solves a problem mentioned in #369 when using MySQL as a remote database. The MySQL handles double quotes with lots of ambiguity and hence a duplicated version with literals surrounded by single quotes is introduced.